### PR TITLE
Add light/dark theme toggle, visual previews, and refactor docs site CSS

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,10 +12,17 @@
   </head>
   <body>
     <div class="page-shell">
+      <header class="topbar panel">
+        <p class="eyebrow">tiagofga/mlp</p>
+        <button class="theme-toggle" type="button" aria-label="Toggle theme" aria-pressed="false">
+          <span class="theme-icon" aria-hidden="true">🌙</span>
+          <span class="theme-label">Dark mode</span>
+        </button>
+      </header>
+
       <main class="container">
         <section class="hero panel">
           <div class="hero-copy">
-            <p class="eyebrow">tiagofga/mlp</p>
             <h1>Modern C++ for reproducible MLP experiments</h1>
             <p class="hero-text">
               Build, benchmark, and reuse a from-scratch multilayer perceptron with
@@ -126,6 +133,56 @@ cmake --build build-blas
           </div>
         </section>
 
+
+        <section class="section-block visual-section panel">
+          <div class="section-heading">
+            <p class="section-kicker">Visual themes</p>
+            <h2>Light and dark previews</h2>
+            <p>Yes — the site can host additional custom images. These preview tiles are SVG-based and easy to replace.</p>
+          </div>
+          <div class="visual-grid">
+            <figure class="visual-card">
+              <svg viewBox="0 0 480 260" role="img" aria-label="Light theme preview" xmlns="http://www.w3.org/2000/svg">
+                <defs><linearGradient id="lg1" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#dbeafe"/><stop offset="100%" stop-color="#eff6ff"/></linearGradient></defs>
+                <rect width="480" height="260" rx="22" fill="url(#lg1)"/>
+                <rect x="32" y="32" width="416" height="42" rx="12" fill="#ffffff"/>
+                <rect x="32" y="92" width="268" height="138" rx="16" fill="#ffffff"/>
+                <rect x="314" y="92" width="134" height="64" rx="16" fill="#bfdbfe"/>
+                <rect x="314" y="166" width="134" height="64" rx="16" fill="#dbeafe"/>
+              </svg>
+              <figcaption>Light mode composition</figcaption>
+            </figure>
+            <figure class="visual-card">
+              <svg viewBox="0 0 480 260" role="img" aria-label="Dark theme preview" xmlns="http://www.w3.org/2000/svg">
+                <defs><linearGradient id="dg1" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0f172a"/><stop offset="100%" stop-color="#111827"/></linearGradient></defs>
+                <rect width="480" height="260" rx="22" fill="url(#dg1)"/>
+                <rect x="32" y="32" width="416" height="42" rx="12" fill="#1e293b"/>
+                <rect x="32" y="92" width="268" height="138" rx="16" fill="#1e293b"/>
+                <rect x="314" y="92" width="134" height="64" rx="16" fill="#1d4ed8"/>
+                <rect x="314" y="166" width="134" height="64" rx="16" fill="#334155"/>
+              </svg>
+              <figcaption>Dark mode composition</figcaption>
+            </figure>
+          </div>
+        </section>
+
+
+        <section class="section-block panel contribute-section">
+          <div class="section-heading">
+            <p class="section-kicker">Contribute</p>
+            <h2>Help build the project with us</h2>
+            <p>
+              If this repository helped your research or learning, consider contributing:
+              report bugs, improve docs, add tests, or propose optimizations.
+              Every issue, discussion, and pull request makes the project stronger.
+            </p>
+          </div>
+          <div class="actions">
+            <a class="btn btn-primary" href="https://github.com/tiagofga/mlp/issues">Open an issue</a>
+            <a class="btn" href="https://github.com/tiagofga/mlp/pulls">Submit a pull request</a>
+          </div>
+        </section>
+
         <section class="section-block">
           <div class="section-heading">
             <p class="section-kicker">Docs and references</p>
@@ -161,5 +218,37 @@ cmake --build build-blas
         </section>
       </main>
     </div>
+
+    <script>
+      const root = document.documentElement;
+      const toggle = document.querySelector('.theme-toggle');
+      const label = toggle?.querySelector('.theme-label');
+      const icon = toggle?.querySelector('.theme-icon');
+      const storedTheme = window.localStorage.getItem('theme');
+      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initialTheme = storedTheme || (systemDark ? 'dark' : 'light');
+
+      const applyTheme = (theme) => {
+        root.setAttribute('data-theme', theme);
+        const dark = theme === 'dark';
+        if (toggle) {
+          toggle.setAttribute('aria-pressed', String(dark));
+        }
+        if (label) {
+          label.textContent = dark ? 'Light mode' : 'Dark mode';
+        }
+        if (icon) {
+          icon.textContent = dark ? '☀️' : '🌙';
+        }
+      };
+
+      applyTheme(initialTheme);
+
+      toggle?.addEventListener('click', () => {
+        const nextTheme = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        window.localStorage.setItem('theme', nextTheme);
+        applyTheme(nextTheme);
+      });
+    </script>
   </body>
 </html>

--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -1,83 +1,53 @@
 :root {
-  color-scheme: light dark;
-  --bg-start: #eff6ff;
-  --bg-end: #f8fafc;
-  --surface: rgba(255, 255, 255, 0.82);
-  --surface-soft: rgba(255, 255, 255, 0.68);
+  --bg-start: #f4f7ff;
+  --bg-end: #eef2ff;
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-soft: rgba(255, 255, 255, 0.72);
   --text: #0f172a;
   --muted: #475569;
-  --border: rgba(15, 23, 42, 0.1);
+  --border: rgba(15, 23, 42, 0.11);
   --primary: #2563eb;
   --primary-strong: #1d4ed8;
-  --primary-fg: #eff6ff;
-  --code-bg: rgba(226, 232, 240, 0.8);
-  --shadow: 0 24px 60px rgba(148, 163, 184, 0.28);
+  --primary-fg: #f8fbff;
+  --code-bg: #eef3ff;
+  --shadow: 0 20px 54px rgba(37, 99, 235, 0.15);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg-start: #0f172a;
-    --bg-end: #020617;
-    --surface: rgba(15, 23, 42, 0.82);
-    --surface-soft: rgba(15, 23, 42, 0.6);
-    --text: #e2e8f0;
-    --muted: #94a3b8;
-    --border: rgba(148, 163, 184, 0.18);
-    --primary: #60a5fa;
-    --primary-strong: #2563eb;
-    --code-bg: rgba(2, 6, 23, 0.88);
-    --shadow: 0 24px 60px rgba(2, 6, 23, 0.45);
-  }
+:root[data-theme='dark'] {
+  --bg-start: #0f172a;
+  --bg-end: #020617;
+  --surface: rgba(15, 23, 42, 0.86);
+  --surface-soft: rgba(15, 23, 42, 0.64);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  --primary: #7db7ff;
+  --primary-strong: #3b82f6;
+  --primary-fg: #0b1120;
+  --code-bg: #0b1223;
+  --shadow: 0 20px 54px rgba(2, 6, 23, 0.52);
 }
 
-* {
-  box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
   line-height: 1.6;
   color: var(--text);
   background:
-    radial-gradient(circle at top, rgba(96, 165, 250, 0.28), transparent 34%),
-    linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 58%, var(--bg-end) 100%);
+    radial-gradient(circle at 12% 0%, rgba(96, 165, 250, 0.24), transparent 36%),
+    radial-gradient(circle at 88% 4%, rgba(56, 189, 248, 0.18), transparent 40%),
+    linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 100%);
 }
 
-a {
-  color: inherit;
-}
+a { color: inherit; }
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace; }
 
-code,
-pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-}
-
-.page-shell {
-  padding: 2rem 1rem 4rem;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.container {
-  width: min(1120px, 100%);
-  margin: 0 auto;
-}
+.page-shell { padding: 1.5rem 1rem 4rem; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+.container { width: min(1120px, 100%); margin: 1rem auto 0; }
 
 .panel {
   background: var(--surface);
@@ -87,241 +57,85 @@ pre {
   backdrop-filter: blur(18px);
 }
 
-.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.9fr);
-  gap: 2rem;
-  padding: 2rem;
-}
-
-.hero-copy,
-.hero-panel {
-  display: grid;
-  gap: 1.5rem;
-  align-content: start;
-}
-
-.eyebrow,
-.section-kicker,
-.resource-tag,
-.info-label {
-  margin: 0;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--primary);
-}
-
-h1,
-h2,
-h3,
-p,
-ul {
-  margin-top: 0;
-}
-
-h1 {
-  margin-bottom: 0;
-  font-size: clamp(2.5rem, 5vw, 4.5rem);
-  line-height: 1.05;
-}
-
-h2 {
-  margin-bottom: 0;
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
-  line-height: 1.1;
-}
-
-h3 {
-  margin-bottom: 0.75rem;
-  font-size: 1.1rem;
-}
-
-.hero-text,
-.section-heading p,
-.feature-card p,
-.workflow-step p,
-.resource-card p,
-.info-list {
-  color: var(--muted);
-}
-
-.hero-text {
-  max-width: 40rem;
-  font-size: 1.05rem;
-}
-
-.actions {
+.topbar {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0.85rem 1rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.9rem;
+  align-items: center;
+  justify-content: space-between;
 }
 
-.btn {
+.theme-toggle {
   display: inline-flex;
+  gap: 0.5rem;
   align-items: center;
-  justify-content: center;
-  min-height: 3rem;
-  padding: 0.75rem 1.1rem;
   border: 1px solid var(--border);
-  border-radius: 999px;
   background: var(--surface-soft);
   color: var(--text);
-  text-decoration: none;
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
   font-weight: 700;
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
 }
 
-.btn:hover,
-.resource-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(96, 165, 250, 0.45);
-}
+.hero { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.9fr); gap: 2rem; padding: 2rem; }
+.hero-copy, .hero-panel { display: grid; gap: 1.5rem; align-content: start; }
+.eyebrow, .section-kicker, .resource-tag, .info-label { margin: 0; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: var(--primary); }
 
-.btn-primary {
-  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
-  color: var(--primary-fg);
-  border-color: transparent;
-}
+h1,h2,h3,p,ul { margin-top: 0; }
+h1 { margin-bottom: 0; font-size: clamp(2.5rem, 5vw, 4.5rem); line-height: 1.05; }
+h2 { margin-bottom: 0; font-size: clamp(1.8rem, 3vw, 2.6rem); line-height: 1.1; }
+h3 { margin-bottom: 0.75rem; font-size: 1.1rem; }
+.hero-text, .section-heading p, .feature-card p, .workflow-step p, .resource-card p, .info-list { color: var(--muted); }
+.hero-text { max-width: 40rem; font-size: 1.05rem; }
 
-.stats-grid,
-.feature-grid,
-.workflow-grid,
-.resource-grid {
-  display: grid;
-  gap: 1rem;
-}
+.actions { display: flex; flex-wrap: wrap; gap: 0.9rem; }
+.btn { display: inline-flex; align-items: center; justify-content: center; min-height: 3rem; padding: 0.75rem 1.1rem; border: 1px solid var(--border); border-radius: 999px; background: var(--surface-soft); text-decoration: none; font-weight: 700; transition: transform .2s ease, border-color .2s ease, background .2s ease; }
+.btn:hover, .resource-card:hover, .theme-toggle:hover { transform: translateY(-2px); border-color: rgba(96, 165, 250, 0.55); }
+.btn-primary { background: linear-gradient(135deg, var(--primary), var(--primary-strong)); color: var(--primary-fg); border-color: transparent; }
 
-.stats-section {
-  display: block;
-}
+.stats-grid,.feature-grid,.workflow-grid,.resource-grid { display: grid; gap: 1rem; }
+.stats-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.stat-card,.terminal-card,.info-card,.workflow-step { padding: 1.25rem; border-radius: 20px; background: var(--surface-soft); border: 1px solid var(--border); }
+.stat-card { display: grid; gap: .35rem; }
+.stat-value { font-size: 1.05rem; font-weight: 800; }
+.stat-label { color: var(--muted); font-size: .95rem; }
 
-.stats-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
+.terminal-title { margin-bottom: .75rem; font-weight: 700; }
+.terminal-title-secondary { margin-top: 1rem; }
+pre { margin: 0; padding: 1rem; overflow-x: auto; border-radius: 16px; background: var(--code-bg); border: 1px solid rgba(96,165,250,.2); }
+.info-list { margin-bottom: 0; padding-left: 1.15rem; }
 
-.stat-card,
-.terminal-card,
-.info-card,
-.workflow-step {
-  padding: 1.25rem;
-  border-radius: 20px;
-  background: var(--surface-soft);
-  border: 1px solid var(--border);
-}
+.section-block { margin-top: 1.5rem; }
+.section-heading { margin-bottom: 1.25rem; }
+.feature-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.feature-card,.resource-card { padding: 1.5rem; }
+.workflow-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.workflow-step { height: 100%; }
+.step-number { display: inline-flex; margin-bottom: 1rem; color: var(--primary); font-weight: 800; }
+.resource-grid { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.resource-card { display: block; text-decoration: none; transition: transform .2s ease, border-color .2s ease; }
 
-.stat-card {
-  display: grid;
-  gap: 0.35rem;
-}
 
-.stat-value {
-  font-size: 1.05rem;
-  font-weight: 800;
-}
+.visual-section p { color: var(--muted); }
+.visual-grid { display:grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap:1rem; }
+.visual-card { margin:0; padding:1rem; border-radius:20px; border:1px solid var(--border); background:var(--surface-soft); }
+.visual-card svg { width:100%; height:auto; display:block; border-radius:14px; }
+.visual-card figcaption { margin-top:.65rem; color:var(--muted); font-weight:600; }
 
-.stat-label {
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.terminal-title {
-  margin-bottom: 0.75rem;
-  font-weight: 700;
-}
-
-.terminal-title-secondary {
-  margin-top: 1rem;
-}
-
-pre {
-  margin: 0;
-  padding: 1rem;
-  overflow-x: auto;
-  border-radius: 16px;
-  background: var(--code-bg);
-  border: 1px solid rgba(96, 165, 250, 0.16);
-}
-
-.info-list {
-  margin-bottom: 0;
-  padding-left: 1.15rem;
-}
-
-.section-block {
-  margin-top: 1.5rem;
-}
-
-.section-heading {
-  margin-bottom: 1.25rem;
-}
-
-.feature-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.feature-card,
-.resource-card {
-  padding: 1.5rem;
-}
-
-.workflow-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.workflow-step {
-  height: 100%;
-}
-
-.step-number {
-  display: inline-flex;
-  margin-bottom: 1rem;
-  color: var(--primary);
-  font-weight: 800;
-}
-
-.resource-grid {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.resource-card {
-  display: block;
-  text-decoration: none;
-  transition: transform 0.2s ease, border-color 0.2s ease;
-}
+.contribute-section p { color: var(--muted); max-width: 52rem; }
 
 @media (max-width: 960px) {
-  .hero,
-  .feature-grid,
-  .workflow-grid,
-  .resource-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .stats-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  .hero,.feature-grid,.workflow-grid,.resource-grid,.visual-grid { grid-template-columns: 1fr; }
+  .stats-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 640px) {
-  .page-shell {
-    padding: 1rem 0.75rem 2.5rem;
-  }
-
-  .hero {
-    padding: 1.25rem;
-  }
-
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
-
-  h1 {
-    font-size: 2.45rem;
-  }
-
-  .btn {
-    width: 100%;
-  }
+  .page-shell { padding: 1rem .75rem 2.5rem; }
+  .hero { padding: 1.25rem; }
+  .stats-grid { grid-template-columns: 1fr; }
+  h1 { font-size: 2.45rem; }
+  .btn { width: 100%; }
+  .theme-label { display: none; }
 }


### PR DESCRIPTION
### Motivation
- Provide a persistent, user-controlled light/dark theme for the documentation site with a visible toggle.
- Surface visual theme previews and a contribution CTA to improve discoverability and polish of the docs landing page.
- Simplify theming by switching from `prefers-color-scheme` media queries to an explicit `data-theme` attribute for predictable runtime switching.
- Modernize and consolidate CSS variables, spacing, and responsive rules for a cleaner, more consistent UI.

### Description
- Updated `docs/site/index.html` to add a `.topbar` header containing the `.theme-toggle`, moved the project eyebrow into the header, added SVG-based theme preview tiles, and added a contribution panel.
- Added an inline theme script that reads/writes the localStorage key `'theme'`, inspects the system preference, and exposes `applyTheme` to toggle `data-theme` on the root element; the `html` element is initialized with `data-theme="light"`.
- Reworked `docs/site/styles.css` to consolidate CSS variables, move dark theme tokens into `:root[data-theme='dark']`, adjust colors/shadows, and add styles for `.theme-toggle`, `.visual-section`, and `.contribute-section` while simplifying and compressing many existing rules.
- Improved responsive behavior and layout spacing for hero, grids, buttons, and cards; updated hover and interaction styles for the new toggle and existing buttons.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0cf1123c8324b18955dfe1ba155a)